### PR TITLE
Fix gcc 13 build

### DIFF
--- a/cbor/encoder.cpp
+++ b/cbor/encoder.cpp
@@ -16,6 +16,8 @@
 
 #include "encoder.h"
 
+#include <cstdint>
+
 using namespace cbor;
 
 


### PR DESCRIPTION
cbor/encoder.cpp:107:21: error: 'uint8_t' was not declared in this scope
note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?